### PR TITLE
Clarify POD for decoded_content charset decoding behavior

### DIFF
--- a/lib/HTTP/Message.pm
+++ b/lib/HTTP/Message.pm
@@ -898,9 +898,14 @@ for details about how charset is determined.
 
 =item $mess->decoded_content( %options )
 
-Returns the content with any C<Content-Encoding> undone and for textual content
-the raw content encoded to Perl's Unicode strings.  If the C<Content-Encoding>
-or C<charset> of the message is unknown this method will fail by returning
+Returns the content with any C<Content-Encoding> undone and, for textual content
+(C<Content-Type> values starting with C<text/>, exactly matching
+C<application/xml>, or ending with C<+xml>), the raw content's character set
+decoded into Perl's Unicode string format. Note that this
+L<does not currently|https://github.com/libwww-perl/HTTP-Message/pull/99>
+attempt to decode declared character sets for any other content types like
+C<application/json> or C<application/javascript>.  If the C<Content-Encoding>
+or C<charset> of the message is unknown, this method will fail by returning
 C<undef>.
 
 The following options can be specified.


### PR DESCRIPTION
In response to [this comment](https://github.com/libwww-perl/HTTP-Message/pull/99#issuecomment-954863759), this PR updates the documentation for decoded_content to clarify the behavior regarding character set decoding of "textual" content.